### PR TITLE
Improve placement of lives, extend level 1 scroll length, adjust truck speed

### DIFF
--- a/src/jaxatari/games/jax_roadrunner.py
+++ b/src/jaxatari/games/jax_roadrunner.py
@@ -77,7 +77,7 @@ class RoadRunnerConstants(NamedTuple):
     TRUCK_SIZE: Tuple[int, int] = (15, 15)
     TRUCK_COLLISION_OFFSET: int = TRUCK_SIZE[1] // 2  # Bottom half of truck height
     TRUCK_COLOR: Tuple[int, int, int] = (255, 0, 0)
-    TRUCK_SPEED: int = 5
+    TRUCK_SPEED: int = 3
     TRUCK_SPAWN_MIN_INTERVAL: int = 30
     TRUCK_SPAWN_MAX_INTERVAL: int = 80
     LEVEL_TRANSITION_DURATION: int = 30


### PR DESCRIPTION
## Changes
✨ Set `LEVEL_COMPLETE_SCROLL_DISTANCE` to 1500 (yields levels that take ~45 seconds to run through uninterrupted, consistent with level 1 in the original)

✨ Tweak `TRUCK_SPEED`: a speed of 3 results in behavior more similar to that of trucks in the original

🎨 Improve placement of lives (see screenshots)


## Screenshots
### Original game
<img width="320" height="446" alt="Javatari Screen (11)" src="https://github.com/user-attachments/assets/65f84e87-a56a-4fda-8a5d-c6a3794b8140" />

### After
<img width="320" height="455" alt="image" src="https://github.com/user-attachments/assets/6693f0e9-18e6-475e-b0b7-7966f7079a13" />


### Before
<img width="319" height="440" alt="image" src="https://github.com/user-attachments/assets/a101a2fc-4aef-47a3-8238-c30ac580f667" />

